### PR TITLE
Ten19 integrate jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,6 @@ In order for typeorm to connect to the database it must know where it is and wha
 `localhost:3000/users`
 
 ## Running the test suite
+1. Run the linter.
+`npm run lint`
 ??????????????

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {
+      "@babel/code-frame": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+         "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+         "dev": true,
+         "requires": {
+            "@babel/highlight": "^7.8.3"
+         }
+      },
+      "@babel/highlight": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+         "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+         "dev": true,
+         "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+         }
+      },
       "@types/color-name": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -115,6 +135,12 @@
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
          "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+      },
+      "builtin-modules": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+         "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+         "dev": true
       },
       "bytes": {
          "version": "3.0.0",
@@ -231,6 +257,12 @@
          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
       },
+      "commander": {
+         "version": "2.20.3",
+         "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+         "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+         "dev": true
+      },
       "concat-map": {
          "version": "0.0.1",
          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -319,6 +351,12 @@
          "version": "4.0.1",
          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      },
+      "esutils": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+         "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+         "dev": true
       },
       "etag": {
          "version": "1.8.1",
@@ -551,6 +589,12 @@
          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
       },
+      "js-tokens": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+         "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+         "dev": true
+      },
       "js-yaml": {
          "version": "3.13.1",
          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -746,6 +790,12 @@
          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
       },
+      "path-parse": {
+         "version": "1.0.6",
+         "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+         "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+         "dev": true
+      },
       "path-to-regexp": {
          "version": "0.1.7",
          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -881,6 +931,15 @@
          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
       },
+      "resolve": {
+         "version": "1.15.1",
+         "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+         "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+         "dev": true,
+         "requires": {
+            "path-parse": "^1.0.6"
+         }
+      },
       "safe-buffer": {
          "version": "5.1.2",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -895,6 +954,12 @@
          "version": "1.2.4",
          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      },
+      "semver": {
+         "version": "5.7.1",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+         "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+         "dev": true
       },
       "send": {
          "version": "0.16.2",
@@ -1078,6 +1143,44 @@
          "version": "1.10.0",
          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      },
+      "tslint": {
+         "version": "6.0.0",
+         "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.0.0.tgz",
+         "integrity": "sha512-9nLya8GBtlFmmFMW7oXXwoXS1NkrccqTqAtwXzdPV9e2mqSEvCki6iHL/Fbzi5oqbugshzgGPk7KBb2qNP1DSA==",
+         "dev": true,
+         "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "builtin-modules": "^1.1.1",
+            "chalk": "^2.3.0",
+            "commander": "^2.12.1",
+            "diff": "^4.0.1",
+            "glob": "^7.1.1",
+            "js-yaml": "^3.13.1",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "resolve": "^1.3.2",
+            "semver": "^5.3.0",
+            "tslib": "^1.10.0",
+            "tsutils": "^2.29.0"
+         },
+         "dependencies": {
+            "diff": {
+               "version": "4.0.2",
+               "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+               "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+               "dev": true
+            }
+         }
+      },
+      "tsutils": {
+         "version": "2.29.0",
+         "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+         "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+         "dev": true,
+         "requires": {
+            "tslib": "^1.8.1"
+         }
       },
       "type-is": {
          "version": "1.6.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,118 @@
             "@babel/highlight": "^7.8.3"
          }
       },
+      "@babel/core": {
+         "version": "7.8.4",
+         "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+         "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
+         "dev": true,
+         "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.4",
+            "@babel/helpers": "^7.8.4",
+            "@babel/parser": "^7.8.4",
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.4",
+            "@babel/types": "^7.8.3",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+         },
+         "dependencies": {
+            "debug": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+               "dev": true,
+               "requires": {
+                  "ms": "^2.1.1"
+               }
+            },
+            "ms": {
+               "version": "2.1.2",
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+               "dev": true
+            },
+            "source-map": {
+               "version": "0.5.7",
+               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+               "dev": true
+            }
+         }
+      },
+      "@babel/generator": {
+         "version": "7.8.4",
+         "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+         "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+         "dev": true,
+         "requires": {
+            "@babel/types": "^7.8.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+         },
+         "dependencies": {
+            "source-map": {
+               "version": "0.5.7",
+               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+               "dev": true
+            }
+         }
+      },
+      "@babel/helper-function-name": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+         "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+         "dev": true,
+         "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+         }
+      },
+      "@babel/helper-get-function-arity": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+         "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+         "dev": true,
+         "requires": {
+            "@babel/types": "^7.8.3"
+         }
+      },
+      "@babel/helper-plugin-utils": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+         "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+         "dev": true
+      },
+      "@babel/helper-split-export-declaration": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+         "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+         "dev": true,
+         "requires": {
+            "@babel/types": "^7.8.3"
+         }
+      },
+      "@babel/helpers": {
+         "version": "7.8.4",
+         "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+         "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
+         "dev": true,
+         "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.4",
+            "@babel/types": "^7.8.3"
+         }
+      },
       "@babel/highlight": {
          "version": "7.8.3",
          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
@@ -24,15 +136,687 @@
             "js-tokens": "^4.0.0"
          }
       },
+      "@babel/parser": {
+         "version": "7.8.4",
+         "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+         "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+         "dev": true
+      },
+      "@babel/plugin-syntax-bigint": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+         "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+         "dev": true,
+         "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+         }
+      },
+      "@babel/plugin-syntax-object-rest-spread": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+         "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+         "dev": true,
+         "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+         }
+      },
+      "@babel/template": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+         "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+         "dev": true,
+         "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+         }
+      },
+      "@babel/traverse": {
+         "version": "7.8.4",
+         "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+         "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+         "dev": true,
+         "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.4",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.4",
+            "@babel/types": "^7.8.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+         },
+         "dependencies": {
+            "debug": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+               "dev": true,
+               "requires": {
+                  "ms": "^2.1.1"
+               }
+            },
+            "ms": {
+               "version": "2.1.2",
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+               "dev": true
+            }
+         }
+      },
+      "@babel/types": {
+         "version": "7.8.3",
+         "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+         "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+         "dev": true,
+         "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+         }
+      },
+      "@bcoe/v8-coverage": {
+         "version": "0.2.3",
+         "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+         "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+         "dev": true
+      },
+      "@cnakazawa/watch": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+         "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+         "dev": true,
+         "requires": {
+            "exec-sh": "^0.3.2",
+            "minimist": "^1.2.0"
+         },
+         "dependencies": {
+            "minimist": {
+               "version": "1.2.0",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+               "dev": true
+            }
+         }
+      },
+      "@istanbuljs/load-nyc-config": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+         "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+         "dev": true,
+         "requires": {
+            "camelcase": "^5.3.1",
+            "find-up": "^4.1.0",
+            "js-yaml": "^3.13.1",
+            "resolve-from": "^5.0.0"
+         }
+      },
+      "@istanbuljs/schema": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+         "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+         "dev": true
+      },
+      "@jest/console": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.1.0.tgz",
+         "integrity": "sha512-3P1DpqAMK/L07ag/Y9/Jup5iDEG9P4pRAuZiMQnU0JB3UOvCyYCjCoxr7sIA80SeyUCUKrr24fKAxVpmBgQonA==",
+         "dev": true,
+         "requires": {
+            "@jest/source-map": "^25.1.0",
+            "chalk": "^3.0.0",
+            "jest-util": "^25.1.0",
+            "slash": "^3.0.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "@jest/core": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/core/-/core-25.1.0.tgz",
+         "integrity": "sha512-iz05+NmwCmZRzMXvMo6KFipW7nzhbpEawrKrkkdJzgytavPse0biEnCNr2wRlyCsp3SmKaEY+SGv7YWYQnIdig==",
+         "dev": true,
+         "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/reporters": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^3.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.3",
+            "jest-changed-files": "^25.1.0",
+            "jest-config": "^25.1.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-resolve-dependencies": "^25.1.0",
+            "jest-runner": "^25.1.0",
+            "jest-runtime": "^25.1.0",
+            "jest-snapshot": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-validate": "^25.1.0",
+            "jest-watcher": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "p-each-series": "^2.1.0",
+            "realpath-native": "^1.1.0",
+            "rimraf": "^3.0.0",
+            "slash": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "@jest/environment": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.1.0.tgz",
+         "integrity": "sha512-cTpUtsjU4cum53VqBDlcW0E4KbQF03Cn0jckGPW/5rrE9tb+porD3+hhLtHAwhthsqfyF+bizyodTlsRA++sHg==",
+         "dev": true,
+         "requires": {
+            "@jest/fake-timers": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "jest-mock": "^25.1.0"
+         }
+      },
+      "@jest/fake-timers": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.1.0.tgz",
+         "integrity": "sha512-Eu3dysBzSAO1lD7cylZd/CVKdZZ1/43SF35iYBNV1Lvvn2Undp3Grwsv8PrzvbLhqwRzDd4zxrY4gsiHc+wygQ==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "lolex": "^5.0.0"
+         }
+      },
+      "@jest/reporters": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.1.0.tgz",
+         "integrity": "sha512-ORLT7hq2acJQa8N+NKfs68ZtHFnJPxsGqmofxW7v7urVhzJvpKZG9M7FAcgh9Ee1ZbCteMrirHA3m5JfBtAaDg==",
+         "dev": true,
+         "requires": {
+            "@bcoe/v8-coverage": "^0.2.3",
+            "@jest/console": "^25.1.0",
+            "@jest/environment": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-instrument": "^4.0.0",
+            "istanbul-lib-report": "^3.0.0",
+            "istanbul-lib-source-maps": "^4.0.0",
+            "istanbul-reports": "^3.0.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-runtime": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-worker": "^25.1.0",
+            "node-notifier": "^6.0.0",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.0",
+            "string-length": "^3.1.0",
+            "terminal-link": "^2.0.0",
+            "v8-to-istanbul": "^4.0.1"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "@jest/source-map": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.1.0.tgz",
+         "integrity": "sha512-ohf2iKT0xnLWcIUhL6U6QN+CwFWf9XnrM2a6ybL9NXxJjgYijjLSitkYHIdzkd8wFliH73qj/+epIpTiWjRtAA==",
+         "dev": true,
+         "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.3",
+            "source-map": "^0.6.0"
+         }
+      },
+      "@jest/test-result": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.1.0.tgz",
+         "integrity": "sha512-FZzSo36h++U93vNWZ0KgvlNuZ9pnDnztvaM7P/UcTx87aPDotG18bXifkf1Ji44B7k/eIatmMzkBapnAzjkJkg==",
+         "dev": true,
+         "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+         }
+      },
+      "@jest/test-sequencer": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.1.0.tgz",
+         "integrity": "sha512-WgZLRgVr2b4l/7ED1J1RJQBOharxS11EFhmwDqknpknE0Pm87HLZVS2Asuuw+HQdfQvm2aXL2FvvBLxOD1D0iw==",
+         "dev": true,
+         "requires": {
+            "@jest/test-result": "^25.1.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-runner": "^25.1.0",
+            "jest-runtime": "^25.1.0"
+         }
+      },
+      "@jest/transform": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.1.0.tgz",
+         "integrity": "sha512-4ktrQ2TPREVeM+KxB4zskAT84SnmG1vaz4S+51aTefyqn3zocZUnliLLm5Fsl85I3p/kFPN4CRp1RElIfXGegQ==",
+         "dev": true,
+         "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^25.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "chalk": "^3.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.3",
+            "jest-haste-map": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "pirates": "^4.0.1",
+            "realpath-native": "^1.1.0",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "^3.0.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "@jest/types": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
+         "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+         "dev": true,
+         "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "@sinonjs/commons": {
+         "version": "1.7.0",
+         "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+         "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+         "dev": true,
+         "requires": {
+            "type-detect": "4.0.8"
+         }
+      },
+      "@types/babel__core": {
+         "version": "7.1.3",
+         "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+         "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
+         "dev": true,
+         "requires": {
+            "@babel/parser": "^7.1.0",
+            "@babel/types": "^7.0.0",
+            "@types/babel__generator": "*",
+            "@types/babel__template": "*",
+            "@types/babel__traverse": "*"
+         }
+      },
+      "@types/babel__generator": {
+         "version": "7.6.1",
+         "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+         "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+         "dev": true,
+         "requires": {
+            "@babel/types": "^7.0.0"
+         }
+      },
+      "@types/babel__template": {
+         "version": "7.0.2",
+         "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+         "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+         "dev": true,
+         "requires": {
+            "@babel/parser": "^7.1.0",
+            "@babel/types": "^7.0.0"
+         }
+      },
+      "@types/babel__traverse": {
+         "version": "7.0.8",
+         "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
+         "integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
+         "dev": true,
+         "requires": {
+            "@babel/types": "^7.3.0"
+         }
+      },
       "@types/color-name": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
       },
+      "@types/istanbul-lib-coverage": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+         "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+         "dev": true
+      },
+      "@types/istanbul-lib-report": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+         "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+         "dev": true,
+         "requires": {
+            "@types/istanbul-lib-coverage": "*"
+         }
+      },
+      "@types/istanbul-reports": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+         "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+         "dev": true,
+         "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+         }
+      },
+      "@types/jest": {
+         "version": "25.1.2",
+         "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.1.2.tgz",
+         "integrity": "sha512-EsPIgEsonlXmYV7GzUqcvORsSS9Gqxw/OvkGwHfAdpjduNRxMlhsav0O5Kb0zijc/eXSO/uW6SJt9nwull8AUQ==",
+         "dev": true,
+         "requires": {
+            "jest-diff": "^25.1.0",
+            "pretty-format": "^25.1.0"
+         }
+      },
       "@types/node": {
          "version": "8.10.59",
          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
          "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
+         "dev": true
+      },
+      "@types/stack-utils": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+         "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+         "dev": true
+      },
+      "@types/yargs": {
+         "version": "15.0.3",
+         "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.3.tgz",
+         "integrity": "sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==",
+         "dev": true,
+         "requires": {
+            "@types/yargs-parser": "*"
+         }
+      },
+      "@types/yargs-parser": {
+         "version": "15.0.0",
+         "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+         "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+         "dev": true
+      },
+      "abab": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+         "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
          "dev": true
       },
       "accepts": {
@@ -42,6 +826,57 @@
          "requires": {
             "mime-types": "~2.1.24",
             "negotiator": "0.6.2"
+         }
+      },
+      "acorn": {
+         "version": "7.1.0",
+         "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+         "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+         "dev": true
+      },
+      "acorn-globals": {
+         "version": "4.3.4",
+         "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+         "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+         "dev": true,
+         "requires": {
+            "acorn": "^6.0.1",
+            "acorn-walk": "^6.0.1"
+         },
+         "dependencies": {
+            "acorn": {
+               "version": "6.4.0",
+               "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+               "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+               "dev": true
+            }
+         }
+      },
+      "acorn-walk": {
+         "version": "6.2.0",
+         "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+         "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+         "dev": true
+      },
+      "ajv": {
+         "version": "6.11.0",
+         "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+         "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+         "dev": true,
+         "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+         }
+      },
+      "ansi-escapes": {
+         "version": "4.3.0",
+         "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+         "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+         "dev": true,
+         "requires": {
+            "type-fest": "^0.8.1"
          }
       },
       "ansi-regex": {
@@ -62,6 +897,16 @@
          "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
       },
+      "anymatch": {
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+         "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+         "dev": true,
+         "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+         }
+      },
       "app-root-path": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
@@ -75,10 +920,40 @@
             "sprintf-js": "~1.0.2"
          }
       },
+      "arr-diff": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+         "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+         "dev": true
+      },
+      "arr-flatten": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+         "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+         "dev": true
+      },
+      "arr-union": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+         "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+         "dev": true
+      },
+      "array-equal": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+         "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+         "dev": true
+      },
       "array-flatten": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+      },
+      "array-unique": {
+         "version": "0.3.2",
+         "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+         "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+         "dev": true
       },
       "arrify": {
          "version": "1.0.1",
@@ -86,15 +961,230 @@
          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
          "dev": true
       },
+      "asn1": {
+         "version": "0.2.4",
+         "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+         "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+         "dev": true,
+         "requires": {
+            "safer-buffer": "~2.1.0"
+         }
+      },
+      "assert-plus": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+         "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+         "dev": true
+      },
+      "assign-symbols": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+         "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+         "dev": true
+      },
+      "astral-regex": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+         "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+         "dev": true
+      },
+      "asynckit": {
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+         "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+         "dev": true
+      },
+      "atob": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+         "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+         "dev": true
+      },
+      "aws-sign2": {
+         "version": "0.7.0",
+         "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+         "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+         "dev": true
+      },
+      "aws4": {
+         "version": "1.9.1",
+         "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+         "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+         "dev": true
+      },
+      "babel-jest": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.1.0.tgz",
+         "integrity": "sha512-tz0VxUhhOE2y+g8R2oFrO/2VtVjA1lkJeavlhExuRBg3LdNJY9gwQ+Vcvqt9+cqy71MCTJhewvTB7Qtnnr9SWg==",
+         "dev": true,
+         "requires": {
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/babel__core": "^7.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "babel-preset-jest": "^25.1.0",
+            "chalk": "^3.0.0",
+            "slash": "^3.0.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "babel-plugin-istanbul": {
+         "version": "6.0.0",
+         "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+         "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+         "dev": true,
+         "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@istanbuljs/load-nyc-config": "^1.0.0",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-instrument": "^4.0.0",
+            "test-exclude": "^6.0.0"
+         }
+      },
+      "babel-plugin-jest-hoist": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.1.0.tgz",
+         "integrity": "sha512-oIsopO41vW4YFZ9yNYoLQATnnN46lp+MZ6H4VvPKFkcc2/fkl3CfE/NZZSmnEIEsJRmJAgkVEK0R7Zbl50CpTw==",
+         "dev": true,
+         "requires": {
+            "@types/babel__traverse": "^7.0.6"
+         }
+      },
+      "babel-preset-jest": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz",
+         "integrity": "sha512-eCGn64olaqwUMaugXsTtGAM2I0QTahjEtnRu0ql8Ie+gDWAc1N6wqN0k2NilnyTunM69Pad7gJY7LOtwLimoFQ==",
+         "dev": true,
+         "requires": {
+            "@babel/plugin-syntax-bigint": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "babel-plugin-jest-hoist": "^25.1.0"
+         }
+      },
       "balanced-match": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
       },
+      "base": {
+         "version": "0.11.2",
+         "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+         "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+         "dev": true,
+         "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+         },
+         "dependencies": {
+            "define-property": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+               "dev": true,
+               "requires": {
+                  "is-descriptor": "^1.0.0"
+               }
+            },
+            "is-accessor-descriptor": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^6.0.0"
+               }
+            },
+            "is-data-descriptor": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^6.0.0"
+               }
+            },
+            "is-descriptor": {
+               "version": "1.0.2",
+               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+               "dev": true,
+               "requires": {
+                  "is-accessor-descriptor": "^1.0.0",
+                  "is-data-descriptor": "^1.0.0",
+                  "kind-of": "^6.0.2"
+               }
+            }
+         }
+      },
       "base64-js": {
          "version": "1.3.1",
          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
          "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      },
+      "bcrypt-pbkdf": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+         "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+         "dev": true,
+         "requires": {
+            "tweetnacl": "^0.14.3"
+         }
       },
       "body-parser": {
          "version": "1.18.3",
@@ -122,6 +1212,56 @@
             "concat-map": "0.0.1"
          }
       },
+      "braces": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+         "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+         "dev": true,
+         "requires": {
+            "fill-range": "^7.0.1"
+         }
+      },
+      "browser-process-hrtime": {
+         "version": "0.1.3",
+         "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+         "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+         "dev": true
+      },
+      "browser-resolve": {
+         "version": "1.11.3",
+         "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+         "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+         "dev": true,
+         "requires": {
+            "resolve": "1.1.7"
+         },
+         "dependencies": {
+            "resolve": {
+               "version": "1.1.7",
+               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+               "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+               "dev": true
+            }
+         }
+      },
+      "bs-logger": {
+         "version": "0.2.6",
+         "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+         "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+         "dev": true,
+         "requires": {
+            "fast-json-stable-stringify": "2.x"
+         }
+      },
+      "bser": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+         "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+         "dev": true,
+         "requires": {
+            "node-int64": "^0.4.0"
+         }
+      },
       "buffer": {
          "version": "5.4.3",
          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
@@ -130,6 +1270,12 @@
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
          }
+      },
+      "buffer-from": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+         "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+         "dev": true
       },
       "buffer-writer": {
          "version": "2.0.0",
@@ -147,6 +1293,50 @@
          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
       },
+      "cache-base": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+         "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+         "dev": true,
+         "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+         }
+      },
+      "callsites": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+         "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+         "dev": true
+      },
+      "camelcase": {
+         "version": "5.3.1",
+         "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+         "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+         "dev": true
+      },
+      "capture-exit": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+         "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+         "dev": true,
+         "requires": {
+            "rsvp": "^4.8.4"
+         }
+      },
+      "caseless": {
+         "version": "0.12.0",
+         "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+         "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+         "dev": true
+      },
       "chalk": {
          "version": "2.4.2",
          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -155,6 +1345,35 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
+         }
+      },
+      "ci-info": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+         "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+         "dev": true
+      },
+      "class-utils": {
+         "version": "0.3.6",
+         "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+         "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+         "dev": true,
+         "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+         },
+         "dependencies": {
+            "define-property": {
+               "version": "0.2.5",
+               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+               "dev": true,
+               "requires": {
+                  "is-descriptor": "^0.1.0"
+               }
+            }
          }
       },
       "cli-highlight": {
@@ -244,6 +1463,39 @@
             }
          }
       },
+      "cliui": {
+         "version": "6.0.0",
+         "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+         "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+         "dev": true,
+         "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+         }
+      },
+      "co": {
+         "version": "4.6.0",
+         "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+         "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+         "dev": true
+      },
+      "collect-v8-coverage": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz",
+         "integrity": "sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==",
+         "dev": true
+      },
+      "collection-visit": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+         "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+         "dev": true,
+         "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+         }
+      },
       "color-convert": {
          "version": "1.9.3",
          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -257,10 +1509,25 @@
          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
       },
+      "combined-stream": {
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+         "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+         "dev": true,
+         "requires": {
+            "delayed-stream": "~1.0.0"
+         }
+      },
       "commander": {
          "version": "2.20.3",
          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+         "dev": true
+      },
+      "component-emitter": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+         "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
          "dev": true
       },
       "concat-map": {
@@ -278,6 +1545,15 @@
          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
       },
+      "convert-source-map": {
+         "version": "1.7.0",
+         "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+         "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+         "dev": true,
+         "requires": {
+            "safe-buffer": "~5.1.1"
+         }
+      },
       "cookie": {
          "version": "0.3.1",
          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -287,6 +1563,74 @@
          "version": "1.0.6",
          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      },
+      "copy-descriptor": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+         "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+         "dev": true
+      },
+      "core-util-is": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+         "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+         "dev": true
+      },
+      "cross-spawn": {
+         "version": "6.0.5",
+         "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+         "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+         "dev": true,
+         "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+         }
+      },
+      "cssom": {
+         "version": "0.4.4",
+         "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+         "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+         "dev": true
+      },
+      "cssstyle": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
+         "integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
+         "dev": true,
+         "requires": {
+            "cssom": "~0.3.6"
+         },
+         "dependencies": {
+            "cssom": {
+               "version": "0.3.8",
+               "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+               "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+               "dev": true
+            }
+         }
+      },
+      "dashdash": {
+         "version": "1.14.1",
+         "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+         "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+         "dev": true,
+         "requires": {
+            "assert-plus": "^1.0.0"
+         }
+      },
+      "data-urls": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+         "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+         "dev": true,
+         "requires": {
+            "abab": "^2.0.0",
+            "whatwg-mimetype": "^2.2.0",
+            "whatwg-url": "^7.0.0"
+         }
       },
       "debug": {
          "version": "2.6.9",
@@ -301,6 +1645,74 @@
          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
       },
+      "decode-uri-component": {
+         "version": "0.2.0",
+         "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+         "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+         "dev": true
+      },
+      "deep-is": {
+         "version": "0.1.3",
+         "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+         "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+         "dev": true
+      },
+      "define-properties": {
+         "version": "1.1.3",
+         "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+         "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+         "dev": true,
+         "requires": {
+            "object-keys": "^1.0.12"
+         }
+      },
+      "define-property": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+         "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+         "dev": true,
+         "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+         },
+         "dependencies": {
+            "is-accessor-descriptor": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^6.0.0"
+               }
+            },
+            "is-data-descriptor": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^6.0.0"
+               }
+            },
+            "is-descriptor": {
+               "version": "1.0.2",
+               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+               "dev": true,
+               "requires": {
+                  "is-accessor-descriptor": "^1.0.0",
+                  "is-data-descriptor": "^1.0.0",
+                  "kind-of": "^6.0.2"
+               }
+            }
+         }
+      },
+      "delayed-stream": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+         "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+         "dev": true
+      },
       "depd": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -311,16 +1723,47 @@
          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
       },
+      "detect-newline": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+         "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+         "dev": true
+      },
       "diff": {
          "version": "3.5.0",
          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
          "dev": true
       },
+      "diff-sequences": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.1.0.tgz",
+         "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
+         "dev": true
+      },
+      "domexception": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+         "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+         "dev": true,
+         "requires": {
+            "webidl-conversions": "^4.0.2"
+         }
+      },
       "dotenv": {
          "version": "6.2.0",
          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
          "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+      },
+      "ecc-jsbn": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+         "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+         "dev": true,
+         "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+         }
       },
       "ee-first": {
          "version": "1.1.1",
@@ -337,6 +1780,45 @@
          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
       },
+      "end-of-stream": {
+         "version": "1.4.4",
+         "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+         "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+         "dev": true,
+         "requires": {
+            "once": "^1.4.0"
+         }
+      },
+      "es-abstract": {
+         "version": "1.17.4",
+         "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+         "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+         "dev": true,
+         "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+         }
+      },
+      "es-to-primitive": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+         "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+         "dev": true,
+         "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+         }
+      },
       "escape-html": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -347,10 +1829,29 @@
          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
       },
+      "escodegen": {
+         "version": "1.14.1",
+         "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+         "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+         "dev": true,
+         "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+         }
+      },
       "esprima": {
          "version": "4.0.1",
          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      },
+      "estraverse": {
+         "version": "4.3.0",
+         "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+         "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+         "dev": true
       },
       "esutils": {
          "version": "2.0.3",
@@ -362,6 +1863,109 @@
          "version": "1.8.1",
          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      },
+      "exec-sh": {
+         "version": "0.3.4",
+         "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+         "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
+         "dev": true
+      },
+      "execa": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+         "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+         "dev": true,
+         "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+         }
+      },
+      "exit": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+         "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+         "dev": true
+      },
+      "expand-brackets": {
+         "version": "2.1.4",
+         "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+         "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+         "dev": true,
+         "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+         },
+         "dependencies": {
+            "define-property": {
+               "version": "0.2.5",
+               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+               "dev": true,
+               "requires": {
+                  "is-descriptor": "^0.1.0"
+               }
+            },
+            "extend-shallow": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+               "dev": true,
+               "requires": {
+                  "is-extendable": "^0.1.0"
+               }
+            }
+         }
+      },
+      "expect": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/expect/-/expect-25.1.0.tgz",
+         "integrity": "sha512-wqHzuoapQkhc3OKPlrpetsfueuEiMf3iWh0R8+duCu9PIjXoP7HgD5aeypwTnXUAjC8aMsiVDaWwlbJ1RlQ38g==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^25.1.0",
+            "jest-matcher-utils": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-regex-util": "^25.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            }
+         }
       },
       "express": {
          "version": "4.16.4",
@@ -400,10 +2004,144 @@
             "vary": "~1.1.2"
          }
       },
+      "extend": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+         "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+         "dev": true
+      },
+      "extend-shallow": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+         "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+         "dev": true,
+         "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+         },
+         "dependencies": {
+            "is-extendable": {
+               "version": "1.0.1",
+               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+               "dev": true,
+               "requires": {
+                  "is-plain-object": "^2.0.4"
+               }
+            }
+         }
+      },
+      "extglob": {
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+         "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+         "dev": true,
+         "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+         },
+         "dependencies": {
+            "define-property": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+               "dev": true,
+               "requires": {
+                  "is-descriptor": "^1.0.0"
+               }
+            },
+            "extend-shallow": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+               "dev": true,
+               "requires": {
+                  "is-extendable": "^0.1.0"
+               }
+            },
+            "is-accessor-descriptor": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^6.0.0"
+               }
+            },
+            "is-data-descriptor": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^6.0.0"
+               }
+            },
+            "is-descriptor": {
+               "version": "1.0.2",
+               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+               "dev": true,
+               "requires": {
+                  "is-accessor-descriptor": "^1.0.0",
+                  "is-data-descriptor": "^1.0.0",
+                  "kind-of": "^6.0.2"
+               }
+            }
+         }
+      },
+      "extsprintf": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+         "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+         "dev": true
+      },
+      "fast-deep-equal": {
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+         "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+         "dev": true
+      },
+      "fast-json-stable-stringify": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+         "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+         "dev": true
+      },
+      "fast-levenshtein": {
+         "version": "2.0.6",
+         "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+         "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+         "dev": true
+      },
+      "fb-watchman": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+         "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+         "dev": true,
+         "requires": {
+            "bser": "2.1.1"
+         }
+      },
       "figlet": {
          "version": "1.2.4",
          "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.2.4.tgz",
          "integrity": "sha512-mv8YA9RruB4C5QawPaD29rEVx3N97ZTyNrE4DAfbhuo6tpcMdKnPVo8MlyT3RP5uPcg5M14bEJBq7kjFf4kAWg=="
+      },
+      "fill-range": {
+         "version": "7.0.1",
+         "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+         "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+         "dev": true,
+         "requires": {
+            "to-regex-range": "^5.0.1"
+         }
       },
       "finalhandler": {
          "version": "1.1.1",
@@ -428,10 +2166,42 @@
             "path-exists": "^4.0.0"
          }
       },
+      "for-in": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+         "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+         "dev": true
+      },
+      "forever-agent": {
+         "version": "0.6.1",
+         "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+         "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+         "dev": true
+      },
+      "form-data": {
+         "version": "2.3.3",
+         "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+         "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+         "dev": true,
+         "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+         }
+      },
       "forwarded": {
          "version": "0.1.2",
          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+      },
+      "fragment-cache": {
+         "version": "0.2.1",
+         "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+         "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+         "dev": true,
+         "requires": {
+            "map-cache": "^0.2.2"
+         }
       },
       "fresh": {
          "version": "0.5.2",
@@ -443,10 +2213,53 @@
          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
       },
+      "fsevents": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+         "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+         "dev": true,
+         "optional": true
+      },
+      "function-bind": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+         "dev": true
+      },
+      "gensync": {
+         "version": "1.0.0-beta.1",
+         "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+         "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+         "dev": true
+      },
       "get-caller-file": {
          "version": "2.0.5",
          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      },
+      "get-stream": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+         "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+         "dev": true,
+         "requires": {
+            "pump": "^3.0.0"
+         }
+      },
+      "get-value": {
+         "version": "2.0.6",
+         "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+         "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+         "dev": true
+      },
+      "getpass": {
+         "version": "0.1.7",
+         "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+         "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+         "dev": true,
+         "requires": {
+            "assert-plus": "^1.0.0"
+         }
       },
       "glob": {
          "version": "7.1.6",
@@ -460,6 +2273,25 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
          }
+      },
+      "globals": {
+         "version": "11.12.0",
+         "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+         "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+         "dev": true
+      },
+      "graceful-fs": {
+         "version": "4.2.3",
+         "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+         "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+         "dev": true
+      },
+      "growly": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+         "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+         "dev": true,
+         "optional": true
       },
       "handlebars": {
          "version": "4.7.1",
@@ -504,6 +2336,31 @@
             }
          }
       },
+      "har-schema": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+         "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+         "dev": true
+      },
+      "har-validator": {
+         "version": "5.1.3",
+         "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+         "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+         "dev": true,
+         "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+         }
+      },
+      "has": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+         "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+         "dev": true,
+         "requires": {
+            "function-bind": "^1.1.1"
+         }
+      },
       "has-ansi": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -524,6 +2381,64 @@
          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
       },
+      "has-symbols": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+         "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+         "dev": true
+      },
+      "has-value": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+         "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+         "dev": true,
+         "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+         }
+      },
+      "has-values": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+         "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+         "dev": true,
+         "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+         },
+         "dependencies": {
+            "is-number": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^3.0.2"
+               },
+               "dependencies": {
+                  "kind-of": {
+                     "version": "3.2.2",
+                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                     "dev": true,
+                     "requires": {
+                        "is-buffer": "^1.1.5"
+                     }
+                  }
+               }
+            },
+            "kind-of": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+               "dev": true,
+               "requires": {
+                  "is-buffer": "^1.1.5"
+               }
+            }
+         }
+      },
       "highlight.js": {
          "version": "9.17.1",
          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.17.1.tgz",
@@ -541,6 +2456,21 @@
             "parse-passwd": "^1.0.0"
          }
       },
+      "html-encoding-sniffer": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+         "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+         "dev": true,
+         "requires": {
+            "whatwg-encoding": "^1.0.1"
+         }
+      },
+      "html-escaper": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+         "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+         "dev": true
+      },
       "http-errors": {
          "version": "1.6.3",
          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -551,6 +2481,23 @@
             "setprototypeof": "1.1.0",
             "statuses": ">= 1.4.0 < 2"
          }
+      },
+      "http-signature": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+         "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+         "dev": true,
+         "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+         }
+      },
+      "human-signals": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+         "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+         "dev": true
       },
       "iconv-lite": {
          "version": "0.4.23",
@@ -564,6 +2511,22 @@
          "version": "1.1.13",
          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      },
+      "import-local": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+         "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+         "dev": true,
+         "requires": {
+            "pkg-dir": "^4.2.0",
+            "resolve-cwd": "^3.0.0"
+         }
+      },
+      "imurmurhash": {
+         "version": "0.1.4",
+         "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+         "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+         "dev": true
       },
       "inflight": {
          "version": "1.0.6",
@@ -579,15 +2542,1553 @@
          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
       },
+      "ip-regex": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+         "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+         "dev": true
+      },
       "ipaddr.js": {
          "version": "1.9.0",
          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
       },
+      "is-accessor-descriptor": {
+         "version": "0.1.6",
+         "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+         "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+         "dev": true,
+         "requires": {
+            "kind-of": "^3.0.2"
+         },
+         "dependencies": {
+            "kind-of": {
+               "version": "3.2.2",
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+               "dev": true,
+               "requires": {
+                  "is-buffer": "^1.1.5"
+               }
+            }
+         }
+      },
+      "is-buffer": {
+         "version": "1.1.6",
+         "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+         "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+         "dev": true
+      },
+      "is-callable": {
+         "version": "1.1.5",
+         "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+         "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+         "dev": true
+      },
+      "is-ci": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+         "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+         "dev": true,
+         "requires": {
+            "ci-info": "^2.0.0"
+         }
+      },
+      "is-data-descriptor": {
+         "version": "0.1.4",
+         "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+         "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+         "dev": true,
+         "requires": {
+            "kind-of": "^3.0.2"
+         },
+         "dependencies": {
+            "kind-of": {
+               "version": "3.2.2",
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+               "dev": true,
+               "requires": {
+                  "is-buffer": "^1.1.5"
+               }
+            }
+         }
+      },
+      "is-date-object": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+         "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+         "dev": true
+      },
+      "is-descriptor": {
+         "version": "0.1.6",
+         "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+         "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+         "dev": true,
+         "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+         },
+         "dependencies": {
+            "kind-of": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+               "dev": true
+            }
+         }
+      },
+      "is-extendable": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+         "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+         "dev": true
+      },
       "is-fullwidth-code-point": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      },
+      "is-generator-fn": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+         "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+         "dev": true
+      },
+      "is-number": {
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+         "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+         "dev": true
+      },
+      "is-plain-object": {
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+         "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+         "dev": true,
+         "requires": {
+            "isobject": "^3.0.1"
+         }
+      },
+      "is-regex": {
+         "version": "1.0.5",
+         "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+         "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+         "dev": true,
+         "requires": {
+            "has": "^1.0.3"
+         }
+      },
+      "is-stream": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+         "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+         "dev": true
+      },
+      "is-symbol": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+         "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+         "dev": true,
+         "requires": {
+            "has-symbols": "^1.0.1"
+         }
+      },
+      "is-typedarray": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+         "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+         "dev": true
+      },
+      "is-windows": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+         "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+         "dev": true
+      },
+      "is-wsl": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+         "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+         "dev": true,
+         "optional": true
+      },
+      "isarray": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+         "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+         "dev": true
+      },
+      "isexe": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+         "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+         "dev": true
+      },
+      "isobject": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+         "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+         "dev": true
+      },
+      "isstream": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+         "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+         "dev": true
+      },
+      "istanbul-lib-coverage": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+         "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+         "dev": true
+      },
+      "istanbul-lib-instrument": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+         "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+         "dev": true,
+         "requires": {
+            "@babel/core": "^7.7.5",
+            "@babel/parser": "^7.7.5",
+            "@babel/template": "^7.7.4",
+            "@babel/traverse": "^7.7.4",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+         },
+         "dependencies": {
+            "semver": {
+               "version": "6.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+               "dev": true
+            }
+         }
+      },
+      "istanbul-lib-report": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+         "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+         "dev": true,
+         "requires": {
+            "istanbul-lib-coverage": "^3.0.0",
+            "make-dir": "^3.0.0",
+            "supports-color": "^7.1.0"
+         },
+         "dependencies": {
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "istanbul-lib-source-maps": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+         "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+         "dev": true,
+         "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^3.0.0",
+            "source-map": "^0.6.1"
+         },
+         "dependencies": {
+            "debug": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+               "dev": true,
+               "requires": {
+                  "ms": "^2.1.1"
+               }
+            },
+            "ms": {
+               "version": "2.1.2",
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+               "dev": true
+            }
+         }
+      },
+      "istanbul-reports": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+         "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+         "dev": true,
+         "requires": {
+            "html-escaper": "^2.0.0",
+            "istanbul-lib-report": "^3.0.0"
+         }
+      },
+      "jest": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest/-/jest-25.1.0.tgz",
+         "integrity": "sha512-FV6jEruneBhokkt9MQk0WUFoNTwnF76CLXtwNMfsc0um0TlB/LG2yxUd0KqaFjEJ9laQmVWQWS0sG/t2GsuI0w==",
+         "dev": true,
+         "requires": {
+            "@jest/core": "^25.1.0",
+            "import-local": "^3.0.2",
+            "jest-cli": "^25.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "jest-cli": {
+               "version": "25.1.0",
+               "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.1.0.tgz",
+               "integrity": "sha512-p+aOfczzzKdo3AsLJlhs8J5EW6ffVidfSZZxXedJ0mHPBOln1DccqFmGCoO8JWd4xRycfmwy1eoQkMsF8oekPg==",
+               "dev": true,
+               "requires": {
+                  "@jest/core": "^25.1.0",
+                  "@jest/test-result": "^25.1.0",
+                  "@jest/types": "^25.1.0",
+                  "chalk": "^3.0.0",
+                  "exit": "^0.1.2",
+                  "import-local": "^3.0.2",
+                  "is-ci": "^2.0.0",
+                  "jest-config": "^25.1.0",
+                  "jest-util": "^25.1.0",
+                  "jest-validate": "^25.1.0",
+                  "prompts": "^2.0.1",
+                  "realpath-native": "^1.1.0",
+                  "yargs": "^15.0.0"
+               }
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-changed-files": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.1.0.tgz",
+         "integrity": "sha512-bdL1aHjIVy3HaBO3eEQeemGttsq1BDlHgWcOjEOIAcga7OOEGWHD2WSu8HhL7I1F0mFFyci8VKU4tRNk+qtwDA==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "execa": "^3.2.0",
+            "throat": "^5.0.0"
+         },
+         "dependencies": {
+            "cross-spawn": {
+               "version": "7.0.1",
+               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+               "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+               "dev": true,
+               "requires": {
+                  "path-key": "^3.1.0",
+                  "shebang-command": "^2.0.0",
+                  "which": "^2.0.1"
+               }
+            },
+            "execa": {
+               "version": "3.4.0",
+               "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+               "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+               "dev": true,
+               "requires": {
+                  "cross-spawn": "^7.0.0",
+                  "get-stream": "^5.0.0",
+                  "human-signals": "^1.1.1",
+                  "is-stream": "^2.0.0",
+                  "merge-stream": "^2.0.0",
+                  "npm-run-path": "^4.0.0",
+                  "onetime": "^5.1.0",
+                  "p-finally": "^2.0.0",
+                  "signal-exit": "^3.0.2",
+                  "strip-final-newline": "^2.0.0"
+               }
+            },
+            "get-stream": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+               "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+               "dev": true,
+               "requires": {
+                  "pump": "^3.0.0"
+               }
+            },
+            "is-stream": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+               "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+               "dev": true
+            },
+            "npm-run-path": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+               "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+               "dev": true,
+               "requires": {
+                  "path-key": "^3.0.0"
+               }
+            },
+            "p-finally": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+               "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+               "dev": true
+            },
+            "path-key": {
+               "version": "3.1.1",
+               "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+               "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+               "dev": true
+            },
+            "shebang-command": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+               "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+               "dev": true,
+               "requires": {
+                  "shebang-regex": "^3.0.0"
+               }
+            },
+            "shebang-regex": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+               "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+               "dev": true
+            },
+            "which": {
+               "version": "2.0.2",
+               "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+               "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+               "dev": true,
+               "requires": {
+                  "isexe": "^2.0.0"
+               }
+            }
+         }
+      },
+      "jest-config": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.1.0.tgz",
+         "integrity": "sha512-tLmsg4SZ5H7tuhBC5bOja0HEblM0coS3Wy5LTCb2C8ZV6eWLewHyK+3qSq9Bi29zmWQ7ojdCd3pxpx4l4d2uGw==",
+         "dev": true,
+         "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/test-sequencer": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "babel-jest": "^25.1.0",
+            "chalk": "^3.0.0",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^25.1.0",
+            "jest-environment-node": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "jest-jasmine2": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-validate": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "pretty-format": "^25.1.0",
+            "realpath-native": "^1.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-diff": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.1.0.tgz",
+         "integrity": "sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==",
+         "dev": true,
+         "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "pretty-format": "^25.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-docblock": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.1.0.tgz",
+         "integrity": "sha512-370P/mh1wzoef6hUKiaMcsPtIapY25suP6JqM70V9RJvdKLrV4GaGbfUseUVk4FZJw4oTZ1qSCJNdrClKt5JQA==",
+         "dev": true,
+         "requires": {
+            "detect-newline": "^3.0.0"
+         }
+      },
+      "jest-each": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.1.0.tgz",
+         "integrity": "sha512-R9EL8xWzoPySJ5wa0DXFTj7NrzKpRD40Jy+zQDp3Qr/2QmevJgkN9GqioCGtAJ2bW9P/MQRznQHQQhoeAyra7A==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "jest-get-type": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "pretty-format": "^25.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-environment-jsdom": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.1.0.tgz",
+         "integrity": "sha512-ILb4wdrwPAOHX6W82GGDUiaXSSOE274ciuov0lztOIymTChKFtC02ddyicRRCdZlB5YSrv3vzr1Z5xjpEe1OHQ==",
+         "dev": true,
+         "requires": {
+            "@jest/environment": "^25.1.0",
+            "@jest/fake-timers": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jsdom": "^15.1.1"
+         }
+      },
+      "jest-environment-node": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.1.0.tgz",
+         "integrity": "sha512-U9kFWTtAPvhgYY5upnH9rq8qZkj6mYLup5l1caAjjx9uNnkLHN2xgZy5mo4SyLdmrh/EtB9UPpKFShvfQHD0Iw==",
+         "dev": true,
+         "requires": {
+            "@jest/environment": "^25.1.0",
+            "@jest/fake-timers": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-util": "^25.1.0"
+         }
+      },
+      "jest-get-type": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
+         "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+         "dev": true
+      },
+      "jest-haste-map": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.1.0.tgz",
+         "integrity": "sha512-/2oYINIdnQZAqyWSn1GTku571aAfs8NxzSErGek65Iu5o8JYb+113bZysRMcC/pjE5v9w0Yz+ldbj9NxrFyPyw==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.3",
+            "jest-serializer": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-worker": "^25.1.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+         }
+      },
+      "jest-jasmine2": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.1.0.tgz",
+         "integrity": "sha512-GdncRq7jJ7sNIQ+dnXvpKO2MyP6j3naNK41DTTjEAhLEdpImaDA9zSAZwDhijjSF/D7cf4O5fdyUApGBZleaEg==",
+         "dev": true,
+         "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@jest/environment": "^25.1.0",
+            "@jest/source-map": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "co": "^4.6.0",
+            "expect": "^25.1.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^25.1.0",
+            "jest-matcher-utils": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-runtime": "^25.1.0",
+            "jest-snapshot": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "pretty-format": "^25.1.0",
+            "throat": "^5.0.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-leak-detector": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.1.0.tgz",
+         "integrity": "sha512-3xRI264dnhGaMHRvkFyEKpDeaRzcEBhyNrOG5oT8xPxOyUAblIAQnpiR3QXu4wDor47MDTiHbiFcbypdLcLW5w==",
+         "dev": true,
+         "requires": {
+            "jest-get-type": "^25.1.0",
+            "pretty-format": "^25.1.0"
+         }
+      },
+      "jest-matcher-utils": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz",
+         "integrity": "sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==",
+         "dev": true,
+         "requires": {
+            "chalk": "^3.0.0",
+            "jest-diff": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "pretty-format": "^25.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-message-util": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.1.0.tgz",
+         "integrity": "sha512-Nr/Iwar2COfN22aCqX0kCVbXgn8IBm9nWf4xwGr5Olv/KZh0CZ32RKgZWMVDXGdOahicM10/fgjdimGNX/ttCQ==",
+         "dev": true,
+         "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^3.0.0",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^1.0.1"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-mock": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.1.0.tgz",
+         "integrity": "sha512-28/u0sqS+42vIfcd1mlcg4ZVDmSUYuNvImP4X2lX5hRMLW+CN0BeiKVD4p+ujKKbSPKd3rg/zuhCF+QBLJ4vag==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0"
+         }
+      },
+      "jest-pnp-resolver": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+         "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+         "dev": true
+      },
+      "jest-regex-util": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.1.0.tgz",
+         "integrity": "sha512-9lShaDmDpqwg+xAd73zHydKrBbbrIi08Kk9YryBEBybQFg/lBWR/2BDjjiSE7KIppM9C5+c03XiDaZ+m4Pgs1w==",
+         "dev": true
+      },
+      "jest-resolve": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.1.0.tgz",
+         "integrity": "sha512-XkBQaU1SRCHj2Evz2Lu4Czs+uIgJXWypfO57L7JYccmAXv4slXA6hzNblmcRmf7P3cQ1mE7fL3ABV6jAwk4foQ==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^3.0.0",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-resolve-dependencies": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.1.0.tgz",
+         "integrity": "sha512-Cu/Je38GSsccNy4I2vL12ZnBlD170x2Oh1devzuM9TLH5rrnLW1x51lN8kpZLYTvzx9j+77Y5pqBaTqfdzVzrw==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-snapshot": "^25.1.0"
+         }
+      },
+      "jest-runner": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.1.0.tgz",
+         "integrity": "sha512-su3O5fy0ehwgt+e8Wy7A8CaxxAOCMzL4gUBftSs0Ip32S0epxyZPDov9Znvkl1nhVOJNf4UwAsnqfc3plfQH9w==",
+         "dev": true,
+         "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/environment": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.3",
+            "jest-config": "^25.1.0",
+            "jest-docblock": "^25.1.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-jasmine2": "^25.1.0",
+            "jest-leak-detector": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-runtime": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-worker": "^25.1.0",
+            "source-map-support": "^0.5.6",
+            "throat": "^5.0.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "source-map-support": {
+               "version": "0.5.16",
+               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+               "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+               "dev": true,
+               "requires": {
+                  "buffer-from": "^1.0.0",
+                  "source-map": "^0.6.0"
+               }
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-runtime": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.1.0.tgz",
+         "integrity": "sha512-mpPYYEdbExKBIBB16ryF6FLZTc1Rbk9Nx0ryIpIMiDDkOeGa0jQOKVI/QeGvVGlunKKm62ywcioeFVzIbK03bA==",
+         "dev": true,
+         "requires": {
+            "@jest/console": "^25.1.0",
+            "@jest/environment": "^25.1.0",
+            "@jest/source-map": "^25.1.0",
+            "@jest/test-result": "^25.1.0",
+            "@jest/transform": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.3",
+            "jest-config": "^25.1.0",
+            "jest-haste-map": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-mock": "^25.1.0",
+            "jest-regex-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "jest-snapshot": "^25.1.0",
+            "jest-util": "^25.1.0",
+            "jest-validate": "^25.1.0",
+            "realpath-native": "^1.1.0",
+            "slash": "^3.0.0",
+            "strip-bom": "^4.0.0",
+            "yargs": "^15.0.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "strip-bom": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+               "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-serializer": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.1.0.tgz",
+         "integrity": "sha512-20Wkq5j7o84kssBwvyuJ7Xhn7hdPeTXndnwIblKDR2/sy1SUm6rWWiG9kSCgJPIfkDScJCIsTtOKdlzfIHOfKA==",
+         "dev": true
+      },
+      "jest-snapshot": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.1.0.tgz",
+         "integrity": "sha512-xZ73dFYN8b/+X2hKLXz4VpBZGIAn7muD/DAg+pXtDzDGw3iIV10jM7WiHqhCcpDZfGiKEj7/2HXAEPtHTj0P2A==",
+         "dev": true,
+         "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "expect": "^25.1.0",
+            "jest-diff": "^25.1.0",
+            "jest-get-type": "^25.1.0",
+            "jest-matcher-utils": "^25.1.0",
+            "jest-message-util": "^25.1.0",
+            "jest-resolve": "^25.1.0",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^25.1.0",
+            "semver": "^7.1.1"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "semver": {
+               "version": "7.1.2",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.2.tgz",
+               "integrity": "sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-util": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.1.0.tgz",
+         "integrity": "sha512-7did6pLQ++87Qsj26Fs/TIwZMUFBXQ+4XXSodRNy3luch2DnRXsSnmpVtxxQ0Yd6WTipGpbhh2IFP1mq6/fQGw==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "chalk": "^3.0.0",
+            "is-ci": "^2.0.0",
+            "mkdirp": "^0.5.1"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-validate": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.1.0.tgz",
+         "integrity": "sha512-kGbZq1f02/zVO2+t1KQGSVoCTERc5XeObLwITqC6BTRH3Adv7NZdYqCpKIZLUgpLXf2yISzQ465qOZpul8abXA==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^3.0.0",
+            "jest-get-type": "^25.1.0",
+            "leven": "^3.1.0",
+            "pretty-format": "^25.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-watcher": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.1.0.tgz",
+         "integrity": "sha512-Q9eZ7pyaIr6xfU24OeTg4z1fUqBF/4MP6J801lyQfg7CsnZ/TCzAPvCfckKdL5dlBBEKBeHV0AdyjFZ5eWj4ig==",
+         "dev": true,
+         "requires": {
+            "@jest/test-result": "^25.1.0",
+            "@jest/types": "^25.1.0",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^3.0.0",
+            "jest-util": "^25.1.0",
+            "string-length": "^3.1.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "chalk": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^4.1.0",
+                  "supports-color": "^7.1.0"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            },
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "jest-worker": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.1.0.tgz",
+         "integrity": "sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==",
+         "dev": true,
+         "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+         },
+         "dependencies": {
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
       },
       "js-tokens": {
          "version": "4.0.0",
@@ -604,6 +4105,135 @@
             "esprima": "^4.0.0"
          }
       },
+      "jsbn": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+         "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+         "dev": true
+      },
+      "jsdom": {
+         "version": "15.2.1",
+         "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+         "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
+         "dev": true,
+         "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^7.1.0",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.4.1",
+            "cssstyle": "^2.0.0",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.2.0",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+         },
+         "dependencies": {
+            "parse5": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+               "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+               "dev": true
+            }
+         }
+      },
+      "jsesc": {
+         "version": "2.5.2",
+         "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+         "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+         "dev": true
+      },
+      "json-schema": {
+         "version": "0.2.3",
+         "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+         "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+         "dev": true
+      },
+      "json-schema-traverse": {
+         "version": "0.4.1",
+         "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+         "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+         "dev": true
+      },
+      "json-stringify-safe": {
+         "version": "5.0.1",
+         "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+         "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+         "dev": true
+      },
+      "json5": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+         "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+         "dev": true,
+         "requires": {
+            "minimist": "^1.2.0"
+         },
+         "dependencies": {
+            "minimist": {
+               "version": "1.2.0",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+               "dev": true
+            }
+         }
+      },
+      "jsprim": {
+         "version": "1.4.1",
+         "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+         "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+         "dev": true,
+         "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+         }
+      },
+      "kind-of": {
+         "version": "6.0.3",
+         "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+         "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+         "dev": true
+      },
+      "kleur": {
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+         "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+         "dev": true
+      },
+      "leven": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+         "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+         "dev": true
+      },
+      "levn": {
+         "version": "0.3.0",
+         "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+         "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+         "dev": true,
+         "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+         }
+      },
       "locate-path": {
          "version": "5.0.0",
          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -612,11 +4242,79 @@
             "p-locate": "^4.1.0"
          }
       },
+      "lodash": {
+         "version": "4.17.15",
+         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+         "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+         "dev": true
+      },
+      "lodash.memoize": {
+         "version": "4.1.2",
+         "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+         "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+         "dev": true
+      },
+      "lodash.sortby": {
+         "version": "4.7.0",
+         "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+         "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+         "dev": true
+      },
+      "lolex": {
+         "version": "5.1.2",
+         "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+         "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+         "dev": true,
+         "requires": {
+            "@sinonjs/commons": "^1.7.0"
+         }
+      },
+      "make-dir": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+         "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+         "dev": true,
+         "requires": {
+            "semver": "^6.0.0"
+         },
+         "dependencies": {
+            "semver": {
+               "version": "6.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+               "dev": true
+            }
+         }
+      },
       "make-error": {
          "version": "1.3.5",
          "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
          "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
          "dev": true
+      },
+      "makeerror": {
+         "version": "1.0.11",
+         "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+         "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+         "dev": true,
+         "requires": {
+            "tmpl": "1.0.x"
+         }
+      },
+      "map-cache": {
+         "version": "0.2.2",
+         "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+         "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+         "dev": true
+      },
+      "map-visit": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+         "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+         "dev": true,
+         "requires": {
+            "object-visit": "^1.0.0"
+         }
       },
       "media-typer": {
          "version": "0.3.0",
@@ -628,10 +4326,26 @@
          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
       },
+      "merge-stream": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+         "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+         "dev": true
+      },
       "methods": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      },
+      "micromatch": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+         "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+         "dev": true,
+         "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+         }
       },
       "mime": {
          "version": "1.4.1",
@@ -651,6 +4365,12 @@
             "mime-db": "1.42.0"
          }
       },
+      "mimic-fn": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+         "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+         "dev": true
+      },
       "minimatch": {
          "version": "3.0.4",
          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -663,6 +4383,27 @@
          "version": "0.0.8",
          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      },
+      "mixin-deep": {
+         "version": "1.3.2",
+         "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+         "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+         "dev": true,
+         "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+         },
+         "dependencies": {
+            "is-extendable": {
+               "version": "1.0.1",
+               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+               "dev": true,
+               "requires": {
+                  "is-plain-object": "^2.0.4"
+               }
+            }
+         }
       },
       "mkdirp": {
          "version": "0.5.1",
@@ -694,6 +4435,31 @@
             "thenify-all": "^1.0.0"
          }
       },
+      "nanomatch": {
+         "version": "1.2.13",
+         "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+         "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+         "dev": true,
+         "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+         }
+      },
+      "natural-compare": {
+         "version": "1.4.0",
+         "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+         "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+         "dev": true
+      },
       "negotiator": {
          "version": "0.6.2",
          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -704,10 +4470,161 @@
          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
       },
+      "nice-try": {
+         "version": "1.0.5",
+         "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+         "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+         "dev": true
+      },
+      "node-int64": {
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+         "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+         "dev": true
+      },
+      "node-modules-regexp": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+         "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+         "dev": true
+      },
+      "node-notifier": {
+         "version": "6.0.0",
+         "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+         "integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^2.1.1",
+            "semver": "^6.3.0",
+            "shellwords": "^0.1.1",
+            "which": "^1.3.1"
+         },
+         "dependencies": {
+            "semver": {
+               "version": "6.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+               "dev": true,
+               "optional": true
+            }
+         }
+      },
+      "normalize-path": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+         "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+         "dev": true
+      },
+      "npm-run-path": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+         "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+         "dev": true,
+         "requires": {
+            "path-key": "^2.0.0"
+         }
+      },
+      "nwsapi": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+         "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+         "dev": true
+      },
+      "oauth-sign": {
+         "version": "0.9.0",
+         "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+         "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+         "dev": true
+      },
       "object-assign": {
          "version": "4.1.1",
          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      },
+      "object-copy": {
+         "version": "0.1.0",
+         "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+         "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+         "dev": true,
+         "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+         },
+         "dependencies": {
+            "define-property": {
+               "version": "0.2.5",
+               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+               "dev": true,
+               "requires": {
+                  "is-descriptor": "^0.1.0"
+               }
+            },
+            "kind-of": {
+               "version": "3.2.2",
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+               "dev": true,
+               "requires": {
+                  "is-buffer": "^1.1.5"
+               }
+            }
+         }
+      },
+      "object-inspect": {
+         "version": "1.7.0",
+         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+         "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+         "dev": true
+      },
+      "object-keys": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+         "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+         "dev": true
+      },
+      "object-visit": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+         "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+         "dev": true,
+         "requires": {
+            "isobject": "^3.0.0"
+         }
+      },
+      "object.assign": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+         "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+         "dev": true,
+         "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+         }
+      },
+      "object.getownpropertydescriptors": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+         "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+         "dev": true,
+         "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1"
+         }
+      },
+      "object.pick": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+         "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+         "dev": true,
+         "requires": {
+            "isobject": "^3.0.1"
+         }
       },
       "on-finished": {
          "version": "2.3.0",
@@ -724,6 +4641,41 @@
          "requires": {
             "wrappy": "1"
          }
+      },
+      "onetime": {
+         "version": "5.1.0",
+         "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+         "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+         "dev": true,
+         "requires": {
+            "mimic-fn": "^2.1.0"
+         }
+      },
+      "optionator": {
+         "version": "0.8.3",
+         "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+         "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+         "dev": true,
+         "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+         }
+      },
+      "p-each-series": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+         "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+         "dev": true
+      },
+      "p-finally": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+         "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+         "dev": true
       },
       "p-limit": {
          "version": "2.2.2",
@@ -780,6 +4732,12 @@
          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
       },
+      "pascalcase": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+         "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+         "dev": true
+      },
       "path-exists": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -789,6 +4747,12 @@
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      },
+      "path-key": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+         "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+         "dev": true
       },
       "path-parse": {
          "version": "1.0.6",
@@ -800,6 +4764,12 @@
          "version": "0.1.7",
          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      },
+      "performance-now": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+         "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+         "dev": true
       },
       "pg": {
          "version": "7.17.0",
@@ -863,6 +4833,42 @@
             "split": "^1.0.0"
          }
       },
+      "picomatch": {
+         "version": "2.2.1",
+         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+         "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+         "dev": true
+      },
+      "pirates": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+         "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+         "dev": true,
+         "requires": {
+            "node-modules-regexp": "^1.0.0"
+         }
+      },
+      "pkg-dir": {
+         "version": "4.2.0",
+         "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+         "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+         "dev": true,
+         "requires": {
+            "find-up": "^4.0.0"
+         }
+      },
+      "pn": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+         "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+         "dev": true
+      },
+      "posix-character-classes": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+         "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+         "dev": true
+      },
       "postgres-array": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -886,6 +4892,61 @@
             "xtend": "^4.0.0"
          }
       },
+      "prelude-ls": {
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+         "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+         "dev": true
+      },
+      "pretty-format": {
+         "version": "25.1.0",
+         "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
+         "integrity": "sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==",
+         "dev": true,
+         "requires": {
+            "@jest/types": "^25.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "4.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+               "dev": true,
+               "requires": {
+                  "@types/color-name": "^1.1.1",
+                  "color-convert": "^2.0.1"
+               }
+            },
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+               "dev": true
+            }
+         }
+      },
+      "prompts": {
+         "version": "2.3.0",
+         "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
+         "integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
+         "dev": true,
+         "requires": {
+            "kleur": "^3.0.3",
+            "sisteransi": "^1.0.3"
+         }
+      },
       "proxy-addr": {
          "version": "2.0.5",
          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -894,6 +4955,28 @@
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.9.0"
          }
+      },
+      "psl": {
+         "version": "1.7.0",
+         "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+         "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+         "dev": true
+      },
+      "pump": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+         "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+         "dev": true,
+         "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+         }
+      },
+      "punycode": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+         "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+         "dev": true
       },
       "qs": {
          "version": "6.5.2",
@@ -916,10 +4999,131 @@
             "unpipe": "1.0.0"
          }
       },
+      "react-is": {
+         "version": "16.12.0",
+         "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+         "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+         "dev": true
+      },
+      "realpath-native": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+         "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+         "dev": true,
+         "requires": {
+            "util.promisify": "^1.0.0"
+         }
+      },
       "reflect-metadata": {
          "version": "0.1.13",
          "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
          "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      },
+      "regex-not": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+         "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+         "dev": true,
+         "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+         }
+      },
+      "remove-trailing-separator": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+         "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+         "dev": true
+      },
+      "repeat-element": {
+         "version": "1.1.3",
+         "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+         "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+         "dev": true
+      },
+      "repeat-string": {
+         "version": "1.6.1",
+         "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+         "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+         "dev": true
+      },
+      "request": {
+         "version": "2.88.0",
+         "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+         "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+         "dev": true,
+         "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+         },
+         "dependencies": {
+            "punycode": {
+               "version": "1.4.1",
+               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+               "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+               "dev": true
+            },
+            "tough-cookie": {
+               "version": "2.4.3",
+               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+               "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+               "dev": true,
+               "requires": {
+                  "psl": "^1.1.24",
+                  "punycode": "^1.4.1"
+               }
+            }
+         }
+      },
+      "request-promise-core": {
+         "version": "1.1.3",
+         "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+         "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+         "dev": true,
+         "requires": {
+            "lodash": "^4.17.15"
+         }
+      },
+      "request-promise-native": {
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+         "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+         "dev": true,
+         "requires": {
+            "request-promise-core": "1.1.3",
+            "stealthy-require": "^1.1.1",
+            "tough-cookie": "^2.3.3"
+         },
+         "dependencies": {
+            "tough-cookie": {
+               "version": "2.5.0",
+               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+               "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+               "dev": true,
+               "requires": {
+                  "psl": "^1.1.28",
+                  "punycode": "^2.1.1"
+               }
+            }
+         }
       },
       "require-directory": {
          "version": "2.1.1",
@@ -940,20 +5144,227 @@
             "path-parse": "^1.0.6"
          }
       },
+      "resolve-cwd": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+         "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+         "dev": true,
+         "requires": {
+            "resolve-from": "^5.0.0"
+         }
+      },
+      "resolve-from": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+         "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+         "dev": true
+      },
+      "resolve-url": {
+         "version": "0.2.1",
+         "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+         "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+         "dev": true
+      },
+      "ret": {
+         "version": "0.1.15",
+         "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+         "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+         "dev": true
+      },
+      "rimraf": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+         "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+         "dev": true,
+         "requires": {
+            "glob": "^7.1.3"
+         }
+      },
+      "rsvp": {
+         "version": "4.8.5",
+         "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+         "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+         "dev": true
+      },
       "safe-buffer": {
          "version": "5.1.2",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      },
+      "safe-regex": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+         "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+         "dev": true,
+         "requires": {
+            "ret": "~0.1.10"
+         }
       },
       "safer-buffer": {
          "version": "2.1.2",
          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
       },
+      "sane": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+         "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+         "dev": true,
+         "requires": {
+            "@cnakazawa/watch": "^1.0.3",
+            "anymatch": "^2.0.0",
+            "capture-exit": "^2.0.0",
+            "exec-sh": "^0.3.2",
+            "execa": "^1.0.0",
+            "fb-watchman": "^2.0.0",
+            "micromatch": "^3.1.4",
+            "minimist": "^1.1.1",
+            "walker": "~1.0.5"
+         },
+         "dependencies": {
+            "anymatch": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+               "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+               "dev": true,
+               "requires": {
+                  "micromatch": "^3.1.4",
+                  "normalize-path": "^2.1.1"
+               }
+            },
+            "braces": {
+               "version": "2.3.2",
+               "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+               "dev": true,
+               "requires": {
+                  "arr-flatten": "^1.1.0",
+                  "array-unique": "^0.3.2",
+                  "extend-shallow": "^2.0.1",
+                  "fill-range": "^4.0.0",
+                  "isobject": "^3.0.1",
+                  "repeat-element": "^1.1.2",
+                  "snapdragon": "^0.8.1",
+                  "snapdragon-node": "^2.0.1",
+                  "split-string": "^3.0.2",
+                  "to-regex": "^3.0.1"
+               },
+               "dependencies": {
+                  "extend-shallow": {
+                     "version": "2.0.1",
+                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                     "dev": true,
+                     "requires": {
+                        "is-extendable": "^0.1.0"
+                     }
+                  }
+               }
+            },
+            "fill-range": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+               "dev": true,
+               "requires": {
+                  "extend-shallow": "^2.0.1",
+                  "is-number": "^3.0.0",
+                  "repeat-string": "^1.6.1",
+                  "to-regex-range": "^2.1.0"
+               },
+               "dependencies": {
+                  "extend-shallow": {
+                     "version": "2.0.1",
+                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                     "dev": true,
+                     "requires": {
+                        "is-extendable": "^0.1.0"
+                     }
+                  }
+               }
+            },
+            "is-number": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^3.0.2"
+               },
+               "dependencies": {
+                  "kind-of": {
+                     "version": "3.2.2",
+                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                     "dev": true,
+                     "requires": {
+                        "is-buffer": "^1.1.5"
+                     }
+                  }
+               }
+            },
+            "micromatch": {
+               "version": "3.1.10",
+               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+               "dev": true,
+               "requires": {
+                  "arr-diff": "^4.0.0",
+                  "array-unique": "^0.3.2",
+                  "braces": "^2.3.1",
+                  "define-property": "^2.0.2",
+                  "extend-shallow": "^3.0.2",
+                  "extglob": "^2.0.4",
+                  "fragment-cache": "^0.2.1",
+                  "kind-of": "^6.0.2",
+                  "nanomatch": "^1.2.9",
+                  "object.pick": "^1.3.0",
+                  "regex-not": "^1.0.0",
+                  "snapdragon": "^0.8.1",
+                  "to-regex": "^3.0.2"
+               }
+            },
+            "minimist": {
+               "version": "1.2.0",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+               "dev": true
+            },
+            "normalize-path": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+               "dev": true,
+               "requires": {
+                  "remove-trailing-separator": "^1.0.1"
+               }
+            },
+            "to-regex-range": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+               "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+               "dev": true,
+               "requires": {
+                  "is-number": "^3.0.0",
+                  "repeat-string": "^1.6.1"
+               }
+            }
+         }
+      },
       "sax": {
          "version": "1.2.4",
          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      },
+      "saxes": {
+         "version": "3.1.11",
+         "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+         "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+         "dev": true,
+         "requires": {
+            "xmlchars": "^2.1.1"
+         }
       },
       "semver": {
          "version": "5.7.1",
@@ -1004,10 +5415,205 @@
          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
       },
+      "set-value": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+         "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+         "dev": true,
+         "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+         },
+         "dependencies": {
+            "extend-shallow": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+               "dev": true,
+               "requires": {
+                  "is-extendable": "^0.1.0"
+               }
+            }
+         }
+      },
       "setprototypeof": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      },
+      "shebang-command": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+         "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+         "dev": true,
+         "requires": {
+            "shebang-regex": "^1.0.0"
+         }
+      },
+      "shebang-regex": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+         "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+         "dev": true
+      },
+      "shellwords": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+         "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+         "dev": true,
+         "optional": true
+      },
+      "signal-exit": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+         "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+         "dev": true
+      },
+      "sisteransi": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
+         "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
+         "dev": true
+      },
+      "slash": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+         "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+         "dev": true
+      },
+      "snapdragon": {
+         "version": "0.8.2",
+         "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+         "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+         "dev": true,
+         "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+         },
+         "dependencies": {
+            "define-property": {
+               "version": "0.2.5",
+               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+               "dev": true,
+               "requires": {
+                  "is-descriptor": "^0.1.0"
+               }
+            },
+            "extend-shallow": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+               "dev": true,
+               "requires": {
+                  "is-extendable": "^0.1.0"
+               }
+            },
+            "source-map": {
+               "version": "0.5.7",
+               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+               "dev": true
+            }
+         }
+      },
+      "snapdragon-node": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+         "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+         "dev": true,
+         "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+         },
+         "dependencies": {
+            "define-property": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+               "dev": true,
+               "requires": {
+                  "is-descriptor": "^1.0.0"
+               }
+            },
+            "is-accessor-descriptor": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^6.0.0"
+               }
+            },
+            "is-data-descriptor": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+               "dev": true,
+               "requires": {
+                  "kind-of": "^6.0.0"
+               }
+            },
+            "is-descriptor": {
+               "version": "1.0.2",
+               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+               "dev": true,
+               "requires": {
+                  "is-accessor-descriptor": "^1.0.0",
+                  "is-data-descriptor": "^1.0.0",
+                  "kind-of": "^6.0.2"
+               }
+            }
+         }
+      },
+      "snapdragon-util": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+         "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+         "dev": true,
+         "requires": {
+            "kind-of": "^3.2.0"
+         },
+         "dependencies": {
+            "kind-of": {
+               "version": "3.2.2",
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+               "dev": true,
+               "requires": {
+                  "is-buffer": "^1.1.5"
+               }
+            }
+         }
+      },
+      "source-map": {
+         "version": "0.6.1",
+         "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+         "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+         "dev": true
+      },
+      "source-map-resolve": {
+         "version": "0.5.3",
+         "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+         "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+         "dev": true,
+         "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+         }
       },
       "source-map-support": {
          "version": "0.4.18",
@@ -1026,6 +5632,12 @@
             }
          }
       },
+      "source-map-url": {
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+         "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+         "dev": true
+      },
       "split": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -1034,15 +5646,101 @@
             "through": "2"
          }
       },
+      "split-string": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+         "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+         "dev": true,
+         "requires": {
+            "extend-shallow": "^3.0.0"
+         }
+      },
       "sprintf-js": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
       },
+      "sshpk": {
+         "version": "1.16.1",
+         "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+         "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+         "dev": true,
+         "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+         }
+      },
+      "stack-utils": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+         "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+         "dev": true
+      },
+      "static-extend": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+         "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+         "dev": true,
+         "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+         },
+         "dependencies": {
+            "define-property": {
+               "version": "0.2.5",
+               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+               "dev": true,
+               "requires": {
+                  "is-descriptor": "^0.1.0"
+               }
+            }
+         }
+      },
       "statuses": {
          "version": "1.4.0",
          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+      },
+      "stealthy-require": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+         "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+         "dev": true
+      },
+      "string-length": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+         "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+         "dev": true,
+         "requires": {
+            "astral-regex": "^1.0.0",
+            "strip-ansi": "^5.2.0"
+         },
+         "dependencies": {
+            "ansi-regex": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+               "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+               "dev": true
+            },
+            "strip-ansi": {
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^4.1.0"
+               }
+            }
+         }
       },
       "string-width": {
          "version": "4.2.0",
@@ -1052,6 +5750,26 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.0"
+         }
+      },
+      "string.prototype.trimleft": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+         "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+         "dev": true,
+         "requires": {
+            "define-properties": "^1.1.3",
+            "function-bind": "^1.1.1"
+         }
+      },
+      "string.prototype.trimright": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+         "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+         "dev": true,
+         "requires": {
+            "define-properties": "^1.1.3",
+            "function-bind": "^1.1.1"
          }
       },
       "strip-ansi": {
@@ -1068,6 +5786,18 @@
          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
          "dev": true
       },
+      "strip-eof": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+         "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+         "dev": true
+      },
+      "strip-final-newline": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+         "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+         "dev": true
+      },
       "strip-json-comments": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -1080,6 +5810,60 @@
          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
          "requires": {
             "has-flag": "^3.0.0"
+         }
+      },
+      "supports-hyperlinks": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+         "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+         "dev": true,
+         "requires": {
+            "has-flag": "^4.0.0",
+            "supports-color": "^7.0.0"
+         },
+         "dependencies": {
+            "has-flag": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^4.0.0"
+               }
+            }
+         }
+      },
+      "symbol-tree": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+         "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+         "dev": true
+      },
+      "terminal-link": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+         "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+         "dev": true,
+         "requires": {
+            "ansi-escapes": "^4.2.1",
+            "supports-hyperlinks": "^2.0.0"
+         }
+      },
+      "test-exclude": {
+         "version": "6.0.0",
+         "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+         "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+         "dev": true,
+         "requires": {
+            "@istanbuljs/schema": "^0.1.2",
+            "glob": "^7.1.4",
+            "minimatch": "^3.0.4"
          }
       },
       "thenify": {
@@ -1098,10 +5882,124 @@
             "thenify": ">= 3.1.0 < 4"
          }
       },
+      "throat": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+         "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+         "dev": true
+      },
       "through": {
          "version": "2.3.8",
          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      },
+      "tmpl": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+         "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+         "dev": true
+      },
+      "to-fast-properties": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+         "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+         "dev": true
+      },
+      "to-object-path": {
+         "version": "0.3.0",
+         "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+         "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+         "dev": true,
+         "requires": {
+            "kind-of": "^3.0.2"
+         },
+         "dependencies": {
+            "kind-of": {
+               "version": "3.2.2",
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+               "dev": true,
+               "requires": {
+                  "is-buffer": "^1.1.5"
+               }
+            }
+         }
+      },
+      "to-regex": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+         "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+         "dev": true,
+         "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+         }
+      },
+      "to-regex-range": {
+         "version": "5.0.1",
+         "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+         "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+         "dev": true,
+         "requires": {
+            "is-number": "^7.0.0"
+         }
+      },
+      "tough-cookie": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+         "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+         "dev": true,
+         "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+         }
+      },
+      "tr46": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+         "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+         "dev": true,
+         "requires": {
+            "punycode": "^2.1.0"
+         }
+      },
+      "ts-jest": {
+         "version": "25.2.0",
+         "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.2.0.tgz",
+         "integrity": "sha512-VaRdb0da46eorLfuHEFf0G3d+jeREcV+Wb/SvW71S4y9Oe8SHWU+m1WY/3RaMknrBsnvmVH0/rRjT8dkgeffNQ==",
+         "dev": true,
+         "requires": {
+            "bs-logger": "0.x",
+            "buffer-from": "1.x",
+            "fast-json-stable-stringify": "2.x",
+            "json5": "2.x",
+            "lodash.memoize": "4.x",
+            "make-error": "1.x",
+            "mkdirp": "0.x",
+            "resolve": "1.x",
+            "semver": "^5.5",
+            "yargs-parser": "10.x"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "yargs-parser": {
+               "version": "10.1.0",
+               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+               "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0"
+               }
+            }
+         }
       },
       "ts-node": {
          "version": "3.3.0",
@@ -1182,6 +6080,42 @@
             "tslib": "^1.8.1"
          }
       },
+      "tunnel-agent": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+         "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+         "dev": true,
+         "requires": {
+            "safe-buffer": "^5.0.1"
+         }
+      },
+      "tweetnacl": {
+         "version": "0.14.5",
+         "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+         "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+         "dev": true
+      },
+      "type-check": {
+         "version": "0.3.2",
+         "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+         "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+         "dev": true,
+         "requires": {
+            "prelude-ls": "~1.1.2"
+         }
+      },
+      "type-detect": {
+         "version": "4.0.8",
+         "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+         "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+         "dev": true
+      },
+      "type-fest": {
+         "version": "0.8.1",
+         "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+         "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+         "dev": true
+      },
       "type-is": {
          "version": "1.6.18",
          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1189,6 +6123,15 @@
          "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
+         }
+      },
+      "typedarray-to-buffer": {
+         "version": "3.1.5",
+         "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+         "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+         "dev": true,
+         "requires": {
+            "is-typedarray": "^1.0.0"
          }
       },
       "typeorm": {
@@ -1347,15 +6290,125 @@
          "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
          "dev": true
       },
+      "union-value": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+         "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+         "dev": true,
+         "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^2.0.1"
+         }
+      },
       "unpipe": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
       },
+      "unset-value": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+         "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+         "dev": true,
+         "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+         },
+         "dependencies": {
+            "has-value": {
+               "version": "0.3.1",
+               "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+               "dev": true,
+               "requires": {
+                  "get-value": "^2.0.3",
+                  "has-values": "^0.1.4",
+                  "isobject": "^2.0.0"
+               },
+               "dependencies": {
+                  "isobject": {
+                     "version": "2.1.0",
+                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                     "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                     "dev": true,
+                     "requires": {
+                        "isarray": "1.0.0"
+                     }
+                  }
+               }
+            },
+            "has-values": {
+               "version": "0.1.4",
+               "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+               "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+               "dev": true
+            }
+         }
+      },
+      "uri-js": {
+         "version": "4.2.2",
+         "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+         "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+         "dev": true,
+         "requires": {
+            "punycode": "^2.1.0"
+         }
+      },
+      "urix": {
+         "version": "0.1.0",
+         "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+         "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+         "dev": true
+      },
+      "use": {
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+         "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+         "dev": true
+      },
+      "util.promisify": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+         "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+         "dev": true,
+         "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.2",
+            "has-symbols": "^1.0.1",
+            "object.getownpropertydescriptors": "^2.1.0"
+         }
+      },
       "utils-merge": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      },
+      "uuid": {
+         "version": "3.4.0",
+         "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+         "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+         "dev": true
+      },
+      "v8-to-istanbul": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.1.tgz",
+         "integrity": "sha512-eDRcudafj/GAV2MSoDNmsV/deeIY9bJ94QuVOzZDEbBd4uX+5v/kODX+p/fqZ74/VYLK1BZv8BPJlNnCV8vDhw==",
+         "dev": true,
+         "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.1",
+            "convert-source-map": "^1.6.0",
+            "source-map": "^0.7.3"
+         },
+         "dependencies": {
+            "source-map": {
+               "version": "0.7.3",
+               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+               "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+               "dev": true
+            }
+         }
       },
       "v8flags": {
          "version": "3.1.3",
@@ -1371,10 +6424,108 @@
          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
       },
+      "verror": {
+         "version": "1.10.0",
+         "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+         "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+         "dev": true,
+         "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+         }
+      },
+      "w3c-hr-time": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+         "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+         "dev": true,
+         "requires": {
+            "browser-process-hrtime": "^0.1.2"
+         }
+      },
+      "w3c-xmlserializer": {
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+         "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+         "dev": true,
+         "requires": {
+            "domexception": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "xml-name-validator": "^3.0.0"
+         }
+      },
+      "walker": {
+         "version": "1.0.7",
+         "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+         "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+         "dev": true,
+         "requires": {
+            "makeerror": "1.0.x"
+         }
+      },
+      "webidl-conversions": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+         "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+         "dev": true
+      },
+      "whatwg-encoding": {
+         "version": "1.0.5",
+         "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+         "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+         "dev": true,
+         "requires": {
+            "iconv-lite": "0.4.24"
+         },
+         "dependencies": {
+            "iconv-lite": {
+               "version": "0.4.24",
+               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+               "dev": true,
+               "requires": {
+                  "safer-buffer": ">= 2.1.2 < 3"
+               }
+            }
+         }
+      },
+      "whatwg-mimetype": {
+         "version": "2.3.0",
+         "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+         "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+         "dev": true
+      },
+      "whatwg-url": {
+         "version": "7.1.0",
+         "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+         "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+         "dev": true,
+         "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+         }
+      },
+      "which": {
+         "version": "1.3.1",
+         "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+         "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+         "dev": true,
+         "requires": {
+            "isexe": "^2.0.0"
+         }
+      },
       "which-module": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+      },
+      "word-wrap": {
+         "version": "1.2.3",
+         "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+         "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+         "dev": true
       },
       "wordwrap": {
          "version": "0.0.3",
@@ -1420,6 +6571,30 @@
          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
       },
+      "write-file-atomic": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+         "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+         "dev": true,
+         "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+         }
+      },
+      "ws": {
+         "version": "7.2.1",
+         "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+         "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+         "dev": true
+      },
+      "xml-name-validator": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+         "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+         "dev": true
+      },
       "xml2js": {
          "version": "0.4.23",
          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -1433,6 +6608,12 @@
          "version": "11.0.1",
          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+      },
+      "xmlchars": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+         "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+         "dev": true
       },
       "xtend": {
          "version": "4.0.2",
@@ -1489,6 +6670,25 @@
                "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
+         }
+      },
+      "yargs": {
+         "version": "15.1.0",
+         "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
+         "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+         "dev": true,
+         "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^16.1.0"
          }
       },
       "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
    "version": "0.0.1",
    "description": "Awesome project developed with TypeORM.",
    "devDependencies": {
-      "ts-node": "3.3.0",
       "@types/node": "^8.0.29",
+      "ts-node": "3.3.0",
+      "tslint": "^6.0.0",
       "typescript": "3.3.3333"
    },
    "dependencies": {
@@ -15,6 +16,7 @@
       "body-parser": "^1.18.1"
    },
    "scripts": {
-      "start": "ts-node src/index.ts"
+      "start": "ts-node src/index.ts",
+      "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'"
    }
 }

--- a/package.json
+++ b/package.json
@@ -3,20 +3,36 @@
    "version": "0.0.1",
    "description": "Awesome project developed with TypeORM.",
    "devDependencies": {
+      "@types/jest": "^25.1.2",
       "@types/node": "^8.0.29",
+      "jest": "^25.1.0",
+      "ts-jest": "^25.2.0",
       "ts-node": "3.3.0",
       "tslint": "^6.0.0",
       "typescript": "3.3.3333"
    },
    "dependencies": {
-      "typeorm": "0.2.22",
-      "reflect-metadata": "^0.1.10",
-      "pg": "^7.3.0",
+      "body-parser": "^1.18.1",
       "express": "^4.15.4",
-      "body-parser": "^1.18.1"
+      "pg": "^7.3.0",
+      "reflect-metadata": "^0.1.10",
+      "typeorm": "0.2.22"
    },
    "scripts": {
       "start": "ts-node src/index.ts",
-      "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'"
+      "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
+      "pretest": "npm run lint",
+      "test": "jest"
+   },
+   "jest": {
+      "moduleFileExtensions": [
+         "ts",
+         "tsx",
+         "js"
+      ],
+      "transform": {
+         "\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      },
+      "testRegex": "/tests/.*\\.(ts|tsx|js)$"
    }
 }

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -15,4 +15,10 @@ export class User {
     @Column()
     age: number;
 
+    constructor(firstName?: string, lastName?: string, age?: number, id?: number) {
+    	this.id = id || null;
+    	this.firstName = firstName || null;
+    	this.lastName = lastName || null;
+    	this.age = age || null;
+    }
 }

--- a/tests/entity/User.test.ts
+++ b/tests/entity/User.test.ts
@@ -1,0 +1,77 @@
+import {User} from "../../src/entity/user";
+
+describe('User', () => {
+	let user = new User();
+	describe("Constructor", () => {
+		describe("Without arguments", () => {
+			it("Instantiates a User", () => {
+				expect(new User()).toBeInstanceOf(User)
+			});
+
+			it("Instantiates a User with all properties set to null", () => {
+				let user = new User();
+				expect(user.id).toBeNull()
+				expect(user.firstName).toBeNull()
+				expect(user.lastName).toBeNull()
+				expect(user.age).toBeNull()
+			});
+		});
+
+		describe("With a single argument", () => {
+			it("Instantiates a User", () => {
+				expect(new User("Cat")).toBeInstanceOf(User)
+			});
+
+			it("Instantiates a User with all properties set to null except firstName", () => {
+				let user = new User("Cat");
+				expect(user.id).toBeNull()
+				expect(user.firstName).toBe("Cat")
+				expect(user.lastName).toBeNull()
+				expect(user.age).toBeNull()
+			});
+		});
+
+		describe("With two arguments", () => {
+			it("Instantiates a User", () => {
+				expect(new User("Cat", "Dog")).toBeInstanceOf(User)
+			});
+
+			it("Instantiates a User with all properties set to null except firstName and lastName", () => {
+				let user = new User("Cat", "Dog");
+				expect(user.id).toBeNull()
+				expect(user.firstName).toBe("Cat")
+				expect(user.lastName).toBe("Dog")
+				expect(user.age).toBeNull()
+			});
+		});
+
+		describe("With three arguments", () => {
+			it("Instantiates a User", () => {
+				expect(new User("Cat", "Dog", 22)).toBeInstanceOf(User)
+			});
+
+			it("Instantiates a User with all properties set to null except firstName, lastName and age", () => {
+				let user = new User("Cat", "Dog", 22);
+				expect(user.id).toBeNull()
+				expect(user.firstName).toBe("Cat")
+				expect(user.lastName).toBe("Dog")
+				expect(user.age).toBe(22)
+			});
+		});
+
+		describe("With four arguments", () => {
+			it("Instantiates a User", () => {
+				expect(new User("Cat", "Dog", 22, 1)).toBeInstanceOf(User)
+			});
+
+			it("Instantiates a User with all properties having a value", () => {
+				let user = new User("Cat", "Dog", 22, 1);
+				expect(user.id).toBe(1)
+				expect(user.firstName).toBe("Cat")
+				expect(user.lastName).toBe("Dog")
+				expect(user.age).toBe(22)
+			});
+		});
+
+	});
+});

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,9 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {},
+    "rulesDirectory": []
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-    "defaultSeverity": "error",
+    "defaultSeverity": "warn",
     "extends": [
         "tslint:recommended"
     ],


### PR DESCRIPTION
Ticket: https://tensorscripts.atlassian.net/browse/TEN-19

This branch adds the Jest test framework along with the tslint linter all configured to run with typescript. Together these two tools will form the core of our testing solution and allow us to deliver code with quality.